### PR TITLE
Upgrade to browser-sync@2.7.12

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var gulp = require('gulp'),
     imagemin = require('gulp-imagemin'),
     clean = require('gulp-clean'),
     concat = require('gulp-concat'),
-    browserSync = require('browser-sync'),
+    browserSync = require('browser-sync').create(),
     cache = require('gulp-cache'),
     rename = require('gulp-rename'),
     sass = require('gulp-sass');
@@ -49,7 +49,9 @@ gulp.task('images', function() {
 
 //browser-sync stuff
 gulp.task('browserSync', function() {
-    browserSync.init(['assets/css/*', '*.php','assets/js/*.js']);
+    browserSync.init({
+      files: ['assets/css/*', '*.php','assets/js/*.js']
+    });
 });
 
 //cleanup time

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.1.0",
   "description": "Generate Random Items to build on the Front End",
   "devDependencies": {
-    "browser-sync": "^0.6.2",
+    "browser-sync": "^2.7.12",
     "gulp": "^3.5.6",
     "gulp-autoprefixer": "0.0.6",
     "gulp-cache": "^0.1.11",


### PR DESCRIPTION
I had some weird issues with the old `browser-sync` that are solved with a newer one.

```
util.js:629
    throw new TypeError('The super constructor to `inherits` must not ' +
          ^
TypeError: The super constructor to `inherits` must not be null or undefined.
```

This patch upgrades `browser-sync` to the latest version.
